### PR TITLE
Update flask-restx to version 0.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "flask-restx" %}
-{% set version = "0.4.0" %}
-{% set sha256 = "8bdbfd8ad2949383c490b3b180481c0e9f70163230a5b567a56592c82f7c5cb0" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "63c69a61999a34f1774eaccc6fc8c7f504b1aad7d56a8ec672264e52d9ac05f4" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   number: 0
-  skip: True  # [py36]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python
     - pip
   run:
-    - python
+    - python >=3.6
     - aniso8601 >=0.82
     - jsonschema
     - flask >=0.8,<2.0.0
@@ -31,6 +31,11 @@ requirements:
 test:
   imports:
     - flask_restx
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/python-restx/flask-restx/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - aniso8601 >=0.82

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 build:
   noarch: python
   number: 0
+  skip: True  # [py36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - python >=3.6
     - aniso8601 >=0.82
     - jsonschema
-    - flask >=0.8,<2.0.0
-    - werkzeug <2.0.0
+    - flask >=0.8,!=2.0.0
+    - werkzeug !=2.0.0
     - pytz
     - six >=1.3.0
 


### PR DESCRIPTION
1. check the upstream
https://github.com/python-restx/flask-restx/tree/0.5.1

2. check the pinnings
https://github.com/python-restx/flask-restx/blob/0.5.1/tox.ini
https://github.com/python-restx/flask-restx/blob/0.5.1/tasks.py
https://github.com/python-restx/flask-restx/blob/0.5.1/setup.py
https://github.com/python-restx/flask-restx/blob/0.5.1/setup.cfg

3. check changelogs
https://github.com/python-restx/flask-restx/blob/0.5.1/CHANGELOG.rst

all of the changes mentioned are bug fixes

- Fix Marshaled nested wildcard field with ordered=True (#326) [bdscharf]
- Fix Float Field Handling of None (#327) [bdscharf, TVLIgnacy]
- Fix Werkzeug and Flask > 2.0 issues (#341) [hbusul]
- Hotfix package.json [xuhdev]

4. additional research
https://github.com/conda-forge/flask-restx-feedstock/issues

5. verify dev_url
6. verify doc_url
7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `flask-restx` package version `0.5.1` the following command was used:
`conda build flask-feedstock --test` 
The test result was the following:
`All tests passed`

In addition the `tranquilizer` package was used to test the `flask-restx` package.
The pinning for `flask-restx` in the `tranquilizer` package was modified to use `0.5.1`
The following command was used:
`conda build tranquilizer-feedstock --test`
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `flask-restx` to version `0.5.1`
