### PR TITLE
flask-restx 1.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
+  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
+  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
-  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
-  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "flask-restx" %}
-{% set version = "1.0.3" %}
-{% set sha256 = "5fdacd23031d25ff4642f141a47a7fa877f07e3e261099ccc5ebc4fc254de84c" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 4f3d3fa7b6191fcc715b18c201a12cd875176f92ba4acc61626ccfd571ee1728
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -28,6 +27,7 @@ requirements:
     - flask >=0.8,!=2.0.0
     - werkzeug !=2.0.0
     - pytz
+    - importlib_resources
 
 test:
   imports:
@@ -44,7 +44,6 @@ about:
   license_file: LICENSE
   license_url: https://github.com/python-restx/flask-restx/blob/master/LICENSE
   summary: Fully featured framework for fast, easy and documented API development with Flask
-
   description: |
     Flask-RESTX is an extension for Flask that adds support for quickly building REST APIs.
     Flask-RESTX encourages best practices with minimal setup. If you are familiar with Flask,
@@ -52,7 +51,6 @@ about:
     tools to describe your API and expose its documentation properly using Swagger.
   doc_url: https://flask-restx.readthedocs.io/
   dev_url: https://github.com/python-restx/flask-restx/
-  doc_source_url: https://github.com/python-restx/flask-restx/blob/master/doc/index.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/python-restx/flask-restx/blob/master/LICENSE
   summary: Fully featured framework for fast, easy and documented API development with Flask
   description: |
     Flask-RESTX is an extension for Flask that adds support for quickly building REST APIs.


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4833](https://anaconda.atlassian.net/browse/PKG-4833)
- release-diff: https://github.com/python-restx/flask-restx//compare/1.0.3...1.3.0
- changelog: https://github.com/python-restx/flask-restx/blob/master/CHANGELOG.rst
- license: https://github.com/python-restx/flask-restx/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/python-restx/flask-restx/tree/1.3.0/requirements
  - https://github.com/python-restx/flask-restx/blob/1.3.0/setup.py


### Explanation of changes:

- Clean up and fix the recipe by conda-lint
- Add importlib_resources to run

### Notes:

- - Updating to make it compatible with `flask 3.0.3` https://github.com/AnacondaRecipes/flask-feedstock/pull/11

[PKG-4833]: https://anaconda.atlassian.net/browse/PKG-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ